### PR TITLE
Force users to check at least one response option per group

### DIFF
--- a/app/commands/concerns/decidim/extra_censuses/update_questions_override.rb
+++ b/app/commands/concerns/decidim/extra_censuses/update_questions_override.rb
@@ -48,7 +48,7 @@ module Decidim
         end
 
         def serialized_settings(question, question_form)
-          base = question.settings.merge("grouped" => question_form.grouped?)
+          base = question.settings.merge("grouped" => question_form.grouped?, "force_one_answer_per_group" => question_form.grouped? && question_form.force_one_answer_per_group?)
           return base.merge("groups" => []) unless question_form.grouped?
 
           base.merge(

--- a/app/controllers/concerns/decidim/extra_censuses/choices_range_check.rb
+++ b/app/controllers/concerns/decidim/extra_censuses/choices_range_check.rb
@@ -16,10 +16,15 @@ module Decidim
 
       def check_choices_range!
         response_ids = params.dig(:response, question.id.to_s) || []
-        return unless out_of_choices_range?(response_ids)
+        if out_of_choices_range?(response_ids)
+          flash.now[:alert] = choices_range_alert_message
+          return render :show
+        end
 
-        flash.now[:alert] = choices_range_alert_message
-        render :show
+        if missing_group_coverage?(response_ids)
+          flash.now[:alert] = I18n.t("must_select_one_per_group", scope: "decidim.elections.votes.question")
+          render :show
+        end
       end
 
       def out_of_choices_range?(response_ids)
@@ -44,6 +49,18 @@ module Decidim
         return I18n.t("min_choices_not_met", min:, scope:) if min
 
         I18n.t("max_choices_exceeded", max:, scope:)
+      end
+
+      def missing_group_coverage?(response_ids)
+        return false unless question.grouped? && question.force_one_answer_per_group?
+        return false if question.groups.empty?
+
+        selected_group_ids = question.response_options
+                                     .where(id: response_ids)
+                                     .pluck(:group_id)
+                                     .to_set
+
+        question.groups.any? { |group| selected_group_ids.exclude?(group.id) }
       end
     end
   end

--- a/app/forms/concerns/decidim/extra_censuses/question_form_override.rb
+++ b/app/forms/concerns/decidim/extra_censuses/question_form_override.rb
@@ -9,6 +9,8 @@ module Decidim
         attribute :min_choices, Integer
         attribute :grouped, :boolean, default: false
         attribute :groups, [Decidim::ExtraCensuses::Elections::Admin::ResponseOptionGroupForm]
+        attribute :force_one_answer_per_group, :boolean, default: false
+        validates :force_one_answer_per_group, absence: true, unless: :grouped?
 
         validates :min_choices,
                   numericality: {
@@ -44,6 +46,7 @@ module Decidim
 
         def map_model(model)
           self.grouped = model.grouped?
+          self.force_one_answer_per_group = model.force_one_answer_per_group?
         end
 
         private

--- a/app/models/concerns/decidim/extra_censuses/question_override.rb
+++ b/app/models/concerns/decidim/extra_censuses/question_override.rb
@@ -13,6 +13,10 @@ module Decidim
         !!settings["grouped"]
       end
 
+      def force_one_answer_per_group?
+        !!settings["force_one_answer_per_group"]
+      end
+
       def groups
         settings.fetch("groups", []).map { |g| Decidim::ExtraCensuses::ResponseOptionGroup.from_settings_hash(g) }.sort_by(&:position)
       end

--- a/app/packs/src/decidim/extra_censuses/controllers/grouped_vote_validation/controller.js
+++ b/app/packs/src/decidim/extra_censuses/controllers/grouped_vote_validation/controller.js
@@ -1,0 +1,43 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static get values() { return { required: Boolean } }
+
+  connect() {
+    if (!this.requiredValue) return
+    this.boundValidate = this.validate.bind(this)
+    this.element.addEventListener("change", this.boundValidate)
+
+    this.form = this.element.closest("form")
+    this.boundPreventSubmit = this.preventSubmit.bind(this)
+    this.form?.addEventListener("submit", this.boundPreventSubmit)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("change", this.boundValidate)
+    this.form?.removeEventListener("submit", this.boundPreventSubmit)
+  }
+
+  validate() {
+    this.groupElements().forEach((groupEl) => {
+      const anyChecked = Array.from(groupEl.querySelectorAll("input[type='checkbox']"))
+        .some((cb) => cb.checked)
+      groupEl.querySelector(".group-one-required-alert")
+        ?.style.setProperty("display", anyChecked ? "none" : "")
+    })
+  }
+
+  preventSubmit(event) {
+    const invalid = this.groupElements().some((groupEl) =>
+      Array.from(groupEl.querySelectorAll("input[type='checkbox']")).every((cb) => !cb.checked)
+    )
+    if (invalid) {
+      event.preventDefault()
+      this.validate()
+    }
+  }
+
+  groupElements() {
+    return Array.from(this.element.querySelectorAll("[data-group-id]"))
+  }
+}

--- a/app/packs/src/decidim/extra_censuses/index.js
+++ b/app/packs/src/decidim/extra_censuses/index.js
@@ -4,6 +4,7 @@ import AdminMinChoicesController from "src/decidim/extra_censuses/controllers/ad
 import GroupedQuestionToggleController from "src/decidim/extra_censuses/controllers/grouped_question_toggle/controller"
 import ResponseOptionGroupsController from "src/decidim/extra_censuses/controllers/response_option_groups/controller"
 import ResponseOptionGroupController from "src/decidim/extra_censuses/controllers/response_option_group/controller"
+import GroupedVoteValidationController from "src/decidim/extra_censuses/controllers/grouped_vote_validation/controller"
 
 let registered = false
 
@@ -11,13 +12,14 @@ document.addEventListener("turbo:load", () => {
   if (registered || !window.Stimulus) {
     return
   }
-
+  
   window.Stimulus.register("custom-csv-census", CustomCsvCensusController)
   window.Stimulus.register("survey-import", SurveyImportController)
   window.Stimulus.register("admin-min-choices", AdminMinChoicesController)
   window.Stimulus.register("grouped-question-toggle", GroupedQuestionToggleController)
   window.Stimulus.register("response-option-groups", ResponseOptionGroupsController)
   window.Stimulus.register("response-option-group", ResponseOptionGroupController)
+  window.Stimulus.register("grouped-vote-validation", GroupedVoteValidationController)
 
   registered = true
 })

--- a/app/views/decidim/extra_censuses/elections/admin/questions/_groups_section.html.erb
+++ b/app/views/decidim/extra_censuses/elections/admin/questions/_groups_section.html.erb
@@ -15,6 +15,17 @@
     <% end %>
   </div>
 
+  <div class="questionnaire-question-force-one-answer-per-group">
+    <label>
+      <%= check_box_tag "questions[#{question.to_param}][force_one_answer_per_group]",
+                        "1",
+                        question.force_one_answer_per_group?,
+                        disabled: !editable %>
+      <%= t("force_one_answer_per_group_label", scope: "decidim.extra_censuses.elections.admin.questions") %>
+    </label>
+    <span class="help-text"><%= t("force_one_answer_per_group_help_text", scope: "decidim.extra_censuses.elections.admin.questions") %></span>
+  </div>
+
   <% ungrouped_options = ungrouped_response_options(question).reject(&:deleted?) %>
   <% if ungrouped_options.any? %>
     <div class="card questionnaire-question-ungrouped-options mx-4 my-8">

--- a/app/views/decidim/extra_censuses/elections/admin/questions/_groups_section.html.erb
+++ b/app/views/decidim/extra_censuses/elections/admin/questions/_groups_section.html.erb
@@ -3,6 +3,19 @@
 <% options_by_group = question.response_options.group_by(&:group_id) %>
 
 <div class="questionnaire-question-groups <%= "hidden" unless question.grouped? %>" data-controller="response-option-groups">
+  <% if editable %>
+    <div class="row column">
+      <label>
+        <%= check_box_tag "questions[#{question.to_param}][force_one_answer_per_group]",
+                          "1",
+                          question.force_one_answer_per_group?,
+                          disabled: !editable %>
+        <%= t("force_one_answer_per_group_label", scope: "decidim.extra_censuses.elections.admin.questions") %>
+      </label>
+      <span class="help-text"><%= t("force_one_answer_per_group_help_text", scope: "decidim.extra_censuses.elections.admin.questions") %></span>
+    </div>
+  <% end %>
+
   <div class="questionnaire-question-groups-list" data-response-option-groups-target="list">
     <% response_option_group_forms(question).each do |group| %>
       <%= fields_for "questions[#{question.to_param}][groups][]", group do |group_form| %>
@@ -13,17 +26,6 @@
                    editable: editable %>
       <% end %>
     <% end %>
-  </div>
-
-  <div class="questionnaire-question-force-one-answer-per-group">
-    <label>
-      <%= check_box_tag "questions[#{question.to_param}][force_one_answer_per_group]",
-                        "1",
-                        question.force_one_answer_per_group?,
-                        disabled: !editable %>
-      <%= t("force_one_answer_per_group_label", scope: "decidim.extra_censuses.elections.admin.questions") %>
-    </label>
-    <span class="help-text"><%= t("force_one_answer_per_group_help_text", scope: "decidim.extra_censuses.elections.admin.questions") %></span>
   </div>
 
   <% ungrouped_options = ungrouped_response_options(question).reject(&:deleted?) %>

--- a/app/views/decidim/extra_censuses/elections/votes/_grouped_question_response_options.html.erb
+++ b/app/views/decidim/extra_censuses/elections/votes/_grouped_question_response_options.html.erb
@@ -1,21 +1,29 @@
-<% grouped_response_options(question).each do |group, options| %>
-  <div class="question-group mt-6">
-    <% if group %>
-      <h3 class="question-group-title h4 mb-4"><%= translated_attribute(group.title) %></h3>
-    <% end %>
-    <div class="question-group-options flex flex-col gap-4">
-      <% options.each do |option| %>
-        <label class="rounded-lg border border-gray p-4 <%= local_assigns[:wrapper_class] %>">
-          <%= render "decidim/elections/votes/responses/multiple_option", option: option %>
-        </label>
+ <div data-controller="grouped-vote-validation" data-grouped-vote-validation-required-value="<%= question.force_one_answer_per_group? %>">
+
+  <% grouped_response_options(question).each do |group, options| %>
+    <div class="question-group mt-6" data-group-id="<%= group&.id %>">
+      <% if group %>
+        <h3 class="question-group-title h4 mb-4"><%= translated_attribute(group.title) %></h3>
+      <% end %>
+      <div class="question-group-options flex flex-col gap-4">
+        <% options.each do |option| %>
+          <label class="rounded-lg border border-gray p-4 <%= local_assigns[:wrapper_class] %>">
+            <%= render "decidim/elections/votes/responses/multiple_option", option: option %>
+          </label>
+        <% end %>
+      </div>
+      <% if question.force_one_answer_per_group? && group %>
+        <small class="form-error group-one-required-alert" style="display:none;">
+          <%= t("must_select_one_per_group", scope: "decidim.elections.votes.question") %>
+        </small>
       <% end %>
     </div>
-  </div>
-<% end %>
+  <% end %>
 
-<%# Upstream client-side contract: decidim-elections/elections.js toggles this %>
-<%# element's style.display when a voter exceeds max_choices. Required or the %>
-<%# upstream JS throws on null when voting on a grouped question with a cap.   %>
-<% if local_assigns[:wrapper_class] && question.max_choices.presence %>
-  <small class="form-error max-choices-alert" style="display:none;"><%= t("max_choices_alert", scope: "decidim.elections.votes.question") %></small>
-<% end %>
+  <%# Upstream client-side contract: decidim-elections/elections.js toggles this %>
+  <%# element's style.display when a voter exceeds max_choices. Required or the %>
+  <%# upstream JS throws on null when voting on a grouped question with a cap.   %>
+  <% if local_assigns[:wrapper_class] && question.max_choices.presence %>
+    <small class="form-error max-choices-alert" style="display:none;"><%= t("max_choices_alert", scope: "decidim.elections.votes.question") %></small>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,8 +152,10 @@ en:
             add_group: "+ Add group"
             collapse: Collapse
             expand: Expand
-            force_one_answer_per_group_label: Force users to check at least one response option per group
-            force_one_answer_per_group_help_text: When enabled, voters must check at least one response option in every group before they can advance.
+            force_one_answer_per_group_help_text: When enabled, voters must check
+              at least one response option in every group before they can advance.
+            force_one_answer_per_group_label: Force users to check at least one response
+              option per group
             group_title_placeholder: Group title
             grouped_help_text: Organize response options into named groups so voters
               see them under subheadings. Global min/max choices still apply to the

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,7 @@ en:
           choices_range: Select between %{min} and %{max} options
           min_choices: Select at least %{count} options
           min_choices_not_met: You must select at least %{min} options.
+          must_select_one_per_group: You must select at least one option in each group.
     extra_censuses:
       elections:
         admin:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,6 +152,8 @@ en:
             add_group: "+ Add group"
             collapse: Collapse
             expand: Expand
+            force_one_answer_per_group_label: Force users to check at least one response option per group
+            force_one_answer_per_group_help_text: When enabled, voters must check at least one response option in every group before they can advance.
             group_title_placeholder: Group title
             grouped_help_text: Organize response options into named groups so voters
               see them under subheadings. Global min/max choices still apply to the

--- a/spec/system/admin/admin_manages_response_option_groups_spec.rb
+++ b/spec/system/admin/admin_manages_response_option_groups_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages response option groups" do
+  let(:manifest_name) { "elections" }
+  let(:participatory_process) { create(:participatory_process, organization:) }
+  let(:current_component) { create(:component, participatory_space: participatory_process, manifest_name: "elections") }
+  let!(:election) { create(:election, component: current_component) }
+
+  include_context "when managing a component as an admin"
+
+  def questions_edit_path
+    Decidim::EngineRouter.admin_proxy(current_component).edit_questions_election_path(election)
+  end
+
+  def open_question_accordion(question_record)
+    find("#questionnaire_question_#{question_record.id}-button").click
+  end
+
+  describe "force one answer per group setting", :js do
+    let!(:question) do
+      create(:election_question,
+             election:,
+             question_type: "multiple_option",
+             settings: {
+               "grouped" => true,
+               "force_one_answer_per_group" => true,
+               "groups" => [
+                 { "id" => "g1", "title" => { "en" => "Group 1" }, "position" => 0 },
+                 { "id" => "g2", "title" => { "en" => "Group 2" }, "position" => 1 },
+                 { "id" => "g3", "title" => { "en" => "Group 3" }, "position" => 2 }
+               ]
+             })
+    end
+
+    before do
+      create(:election_response_option, question:, group_id: "g1", body: { "en" => "Option 1A" })
+      create(:election_response_option, question:, group_id: "g1", body: { "en" => "Option 1B" })
+      create(:election_response_option, question:, group_id: "g2", body: { "en" => "Option 2A" })
+      create(:election_response_option, question:, group_id: "g2", body: { "en" => "Option 2B" })
+      create(:election_response_option, question:, group_id: "g3", body: { "en" => "Option 3A" })
+      create(:election_response_option, question:, group_id: "g3", body: { "en" => "Option 3B" })
+      visit questions_edit_path
+      open_question_accordion(question)
+    end
+
+    it "persists the force_one_answer_per_group setting with multiple groups" do
+      click_on "Save and continue"
+      expect(page).to have_admin_callout("successfully")
+
+      question.reload
+      expect(question.force_one_answer_per_group?).to be true
+      expect(question.groups.size).to eq(3)
+    end
+
+    it "maintains the setting when adding a new group" do
+      within "#accordion-questionnaire_question_#{question.id}-field" do
+        click_on "+ Add group"
+
+        new_group = all(".questionnaire-question-group").last
+        within new_group do
+          fill_in find_nested_form_field_locator("title_en"), with: "Group 4"
+
+          new_option = all(".questionnaire-question-response-option").last
+          within new_option do
+            fill_in find_nested_form_field_locator("body_en"), with: "Option 4A"
+          end
+        end
+      end
+
+      click_on "Save and continue"
+      expect(page).to have_admin_callout("successfully")
+
+      question.reload
+      expect(question.force_one_answer_per_group?).to be true
+      expect(question.groups.size).to eq(4)
+    end
+
+    it "maintains the setting when removing a group" do
+      within "#accordion-questionnaire_question_#{question.id}-field" do
+        groups = all(".questionnaire-question-group")
+
+        within groups.last do
+          all(".remove-response-option").each(&:click)
+        end
+      end
+
+      click_on "Save and continue"
+      expect(page).to have_admin_callout("successfully")
+
+      question.reload
+      expect(question.force_one_answer_per_group?).to be true
+      expect(question.groups.size).to eq(2)
+    end
+
+    it "displays all groups correctly in the admin interface" do
+      within "#accordion-questionnaire_question_#{question.id}-field" do
+        groups = all(".questionnaire-question-group")
+
+        expect(groups.size).to eq(3)
+
+        within groups[0] do
+          expect(page).to have_css("input[value='Group 1']")
+          expect(page).to have_css("input[value='Option 1A']")
+          expect(page).to have_css("input[value='Option 1B']")
+        end
+
+        within groups[1] do
+          expect(page).to have_css("input[value='Group 2']")
+          expect(page).to have_css("input[value='Option 2A']")
+          expect(page).to have_css("input[value='Option 2B']")
+        end
+
+        within groups[2] do
+          expect(page).to have_css("input[value='Group 3']")
+          expect(page).to have_css("input[value='Option 3A']")
+          expect(page).to have_css("input[value='Option 3B']")
+        end
+      end
+    end
+  end
+
+  private
+
+  def find_nested_form_field_locator(attribute, visible: :visible)
+    find_nested_form_field(attribute, visible:)["id"]
+  end
+
+  def find_nested_form_field(attribute, visible: :visible)
+    current_scope.find(nested_form_field_selector(attribute), visible:, match: :first)
+  end
+
+  def nested_form_field_selector(attribute)
+    "[id$=#{attribute}]"
+  end
+end

--- a/spec/system/user_votes_with_force_one_answer_per_group_spec.rb
+++ b/spec/system/user_votes_with_force_one_answer_per_group_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "User votes with force one answer per group" do
+  let(:organization) { election.organization }
+  let(:user) { create(:user, :confirmed, organization:) }
+  let(:election_path) { Decidim::EngineRouter.main_proxy(election.component).election_path(election) }
+
+  let(:group_a_id) { "aaaa0001" }
+  let(:group_b_id) { "bbbb0002" }
+  let(:group_c_id) { "cccc0003" }
+
+  let(:grouped_settings) do
+    {
+      "grouped" => true,
+      "force_one_answer_per_group" => true,
+      "groups" => [
+        { "id" => group_a_id, "title" => { "en" => "Animals" }, "position" => 0 },
+        { "id" => group_b_id, "title" => { "en" => "Plants" }, "position" => 1 },
+        { "id" => group_c_id, "title" => { "en" => "Mountains" }, "position" => 2 }
+      ]
+    }
+  end
+
+  context "when the election is a normal (all-at-once) one" do
+    let!(:election) { create(:election, :published, :ongoing, :with_internal_users_census) }
+    let!(:question) do
+      create(:election_question,
+             election:,
+             question_type: "multiple_option",
+             settings: grouped_settings,
+             skip_injection: true)
+    end
+
+    let!(:option_a1) { create(:election_response_option, question:, group_id: group_a_id, body: { "en" => "Cat" }) }
+    let!(:option_a2) { create(:election_response_option, question:, group_id: group_a_id, body: { "en" => "Dog" }) }
+    let!(:option_b1) { create(:election_response_option, question:, group_id: group_b_id, body: { "en" => "Oak" }) }
+    let!(:option_c1) { create(:election_response_option, question:, group_id: group_c_id, body: { "en" => "Everest" }) }
+
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit election_path
+      click_on "Vote"
+    end
+
+    it "shows validation error when trying to vote without selecting from all groups", :js do
+      check translated_attribute(option_a1.body)
+
+      click_on "Next"
+
+      expect(page).to have_content("must select at least one option").or have_content("required")
+    end
+
+    it "shows validation error when skipping a group", :js do
+      check translated_attribute(option_a1.body)
+      check translated_attribute(option_c1.body)
+
+      click_on "Next"
+
+      expect(page).to have_content("must select at least one option").or have_content("required")
+    end
+
+    it "allows voting when at least one option is selected from each group" do
+      check translated_attribute(option_a1.body)
+      check translated_attribute(option_b1.body)
+      check translated_attribute(option_c1.body)
+
+      click_on "Next"
+      click_on "Cast vote" if page.has_button?("Cast vote")
+
+      expect(page).to have_content("successfully cast")
+    end
+
+    it "allows selecting multiple options from the same group" do
+      check translated_attribute(option_a1.body)
+      check translated_attribute(option_a2.body)
+      check translated_attribute(option_b1.body)
+      check translated_attribute(option_c1.body)
+
+      click_on "Next"
+      click_on "Cast vote" if page.has_button?("Cast vote")
+
+      expect(page).to have_content("successfully cast")
+
+      voter_uid = user.to_global_id.to_s
+      voted_option_ids = Decidim::Elections::Vote.where(voter_uid:, question:).pluck(:response_option_id)
+      expect(voted_option_ids).to contain_exactly(option_a1.id, option_a2.id, option_b1.id, option_c1.id)
+    end
+  end
+
+  context "when mixing grouped questions with and without force_one_answer_per_group" do
+    let!(:election) { create(:election, :published, :ongoing, :with_internal_users_census) }
+
+    let!(:question_forced) do
+      create(:election_question,
+             election:,
+             question_type: "multiple_option",
+             settings: grouped_settings,
+             body: { "en" => "Question with force (required)" },
+             skip_injection: true)
+    end
+
+    let!(:question_free) do
+      create(:election_question,
+             election:,
+             question_type: "multiple_option",
+             settings: {
+               "grouped" => true,
+               "force_one_answer_per_group" => false,
+               "groups" => [
+                 { "id" => "free_a", "title" => { "en" => "Colors" }, "position" => 0 },
+                 { "id" => "free_b", "title" => { "en" => "Shapes" }, "position" => 1 }
+               ]
+             },
+             body: { "en" => "Question without force (optional)" },
+             skip_injection: true)
+    end
+
+    let!(:option_a1) { create(:election_response_option, question: question_forced, group_id: group_a_id, body: { "en" => "Cat" }) }
+    let!(:option_b1) { create(:election_response_option, question: question_forced, group_id: group_b_id, body: { "en" => "Oak" }) }
+    let!(:option_c1) { create(:election_response_option, question: question_forced, group_id: group_c_id, body: { "en" => "Everest" }) }
+
+    let!(:option_free_a1) { create(:election_response_option, question: question_free, group_id: "free_a", body: { "en" => "Red" }) }
+
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit election_path
+      click_on "Vote"
+    end
+
+    it "requires selection from all groups only on the forced question", :js do
+      check translated_attribute(option_a1.body)
+      check translated_attribute(option_b1.body)
+      check translated_attribute(option_c1.body)
+
+      click_on "Next"
+
+      check translated_attribute(option_free_a1.body)
+
+      click_on "Next"
+      click_on "Cast vote" if page.has_button?("Cast vote")
+
+      expect(page).to have_content("successfully cast")
+    end
+
+    it "shows error when forced question groups are not all selected", :js do
+      check translated_attribute(option_a1.body)
+      check translated_attribute(option_b1.body)
+
+      click_on "Next"
+
+      expect(page).to have_content("must select at least one option").or have_content("required")
+    end
+  end
+end


### PR DESCRIPTION
🎩 What? Why?
Grouped multi-answer questions can now require voters to select at least one response option from every group before submitting their vote.

📌 Related Issues
Link your PR to an issue
Related to #? 
Fixes [#214](https://github.com/Som-Energia/decidim-som-energia-app/issues/214)

📷 Screenshots
<img width="1238" height="966" alt="image" src="https://github.com/user-attachments/assets/71a84bfd-1c6d-4a65-960a-26db513e1196" />
This is an optional checkbox
<img width="1662" height="955" alt="image" src="https://github.com/user-attachments/assets/a4398d74-fa63-416b-a6fd-a00c002c661e" />
User feedback in public view

♥️ Thank you!
