### PR TITLE
use normal before_action to preserve locales

### DIFF
--- a/app/controllers/concerns/decidim/extra_censuses/choices_range_check.rb
+++ b/app/controllers/concerns/decidim/extra_censuses/choices_range_check.rb
@@ -9,7 +9,7 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
-        prepend_before_action :check_choices_range!, only: :update # rubocop:disable Rails/LexicallyScopedActionFilter
+        before_action :check_choices_range!, only: :update # rubocop:disable Rails/LexicallyScopedActionFilter
       end
 
       private


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted callback execution ordering for internal validation processes to improve system reliability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openpoke/decidim-module-extra_censuses/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->